### PR TITLE
Add imread_rgb convenience helper

### DIFF
--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -20,6 +20,39 @@ except ImportError:
 # is_x64 = sys.maxsize > 2**32
 
 
+def imread_rgb(filename, flags=1):
+    """Read an image file and convert it from BGR to RGB order.
+
+    The regular :func:`imread` function in OpenCV loads color images in
+    BGR channel order which is often confusing for newcomers that expect
+    RGB ordering. This helper mirrors :func:`imread` but swaps the color
+    channels so that the returned image uses the more common RGB layout.
+
+    Parameters
+    ----------
+    filename: str
+        Path to the image file to load.
+    flags: int, optional
+        Same flags as used by :func:`imread`. By default ``IMREAD_COLOR``.
+
+    Returns
+    -------
+    Mat or ``None``
+        Loaded image in RGB order, or ``None`` if the image cannot be
+        read. Images with a number of channels different from three are
+        returned unchanged.
+    """
+    img = imread(filename, flags)
+    if img is None:
+        return None
+    # only convert if image has 3 channels
+    if getattr(img, 'shape', None) is not None and len(img.shape) == 3 and img.shape[2] == 3:
+        return cvtColor(img, COLOR_BGR2RGB)
+    return img
+
+__all__.append('imread_rgb')
+
+
 def __load_extra_py_code_for_module(base, name, enable_debug_print=False):
     module_name = "{}.{}".format(__name__, name)
     export_module_name = "{}.{}".format(base, name)

--- a/modules/python/test/test_imread_rgb.py
+++ b/modules/python/test/test_imread_rgb.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import cv2 as cv
+from tests_common import NewOpenCVTests
+
+
+class imread_rgb_test(NewOpenCVTests):
+    def test_imread_rgb(self):
+        path = self.extraTestDataPath + '/cv/shared/lena.png'
+        bgr = cv.imread(path)
+        rgb = cv.imread_rgb(path)
+        self.assertEqual(bgr.shape, rgb.shape)
+        bgr2rgb = cv.cvtColor(bgr, cv.COLOR_BGR2RGB)
+        self.assertEqual(cv.norm(rgb, bgr2rgb, cv.NORM_INF), 0.0)
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()


### PR DESCRIPTION
## Summary
- add `imread_rgb` helper to load images as RGB instead of BGR
- test helper against equivalent `cvtColor` conversion

## Testing
- `python3 -m pytest modules/python/test/test_imread_rgb.py -q` *(fails: unsupported operand type(s) for +: 'NoneType' and 'str')*


------
https://chatgpt.com/codex/tasks/task_e_68b2ddf996c883338c1e813625fffdc0