### PR TITLE
feat: add URL image reader utility

### DIFF
--- a/modules/python/test/test_imread_url.py
+++ b/modules/python/test/test_imread_url.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import urllib.error
+import pytest
+import cv2 as cv
+
+# ensure sample utilities are on path
+SAMPLES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../samples/python'))
+if SAMPLES_DIR not in sys.path:
+    sys.path.insert(0, SAMPLES_DIR)
+from common import imread_url
+
+
+def test_imread_url():
+    url = 'https://raw.githubusercontent.com/opencv/opencv/master/samples/data/lena.jpg'
+    try:
+        img = imread_url(url, cv.IMREAD_GRAYSCALE)
+    except urllib.error.URLError:
+        pytest.skip('No internet access to fetch test image')
+    assert img is not None
+    assert img.ndim == 2
+    h, w = img.shape[:2]
+    assert h > 0 and w > 0

--- a/samples/python/common.py
+++ b/samples/python/common.py
@@ -19,8 +19,28 @@ import cv2 as cv
 import os
 import itertools as it
 from contextlib import contextmanager
+import urllib.request
 
 image_extensions = ['.bmp', '.jpg', '.jpeg', '.png', '.tif', '.tiff', '.pbm', '.pgm', '.ppm']
+
+def imread_url(url, flags=cv.IMREAD_COLOR):
+    """Fetch an image from the internet and decode it as an OpenCV array.
+
+    Parameters
+    ----------
+    url : str
+        HTTP/HTTPS URL pointing to an image resource.
+    flags : int, optional
+        Imread flags as in :func:`cv.imread`.
+
+    Returns
+    -------
+    numpy.ndarray
+        Decoded image matrix or ``None`` on failure.
+    """
+    with urllib.request.urlopen(url) as resp:
+        data = np.asarray(bytearray(resp.read()), dtype=np.uint8)
+    return cv.imdecode(data, flags)
 
 class Bunch(object):
     def __init__(self, **kw):

--- a/samples/python/imread_url.py
+++ b/samples/python/imread_url.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""Sample demonstrating how to load an image from a web URL with OpenCV."""
+
+import sys
+import cv2 as cv
+from common import imread_url
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: imread_url.py <image_url>")
+        return
+    url = sys.argv[1]
+    img = imread_url(url)
+    if img is None:
+        print("Failed to load image from", url)
+        return
+    print("Loaded image shape:", img.shape)
+    cv.imshow('URL image', img)
+    cv.waitKey(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `imread_url` helper to load images directly from a web URL
- provide Python sample demonstrating usage
- add regression test for URL image loading

## Testing
- `python -m py_compile samples/python/common.py samples/python/imread_url.py modules/python/test/test_imread_url.py`
- `pytest modules/python/test/test_imread_url.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2ddf996c883338c1e813625fffdc0