### PR TITLE
imgproc: add adaptive tile-based goodFeaturesToTrack API

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2166,6 +2166,40 @@ CV_EXPORTS CV_WRAP_AS(goodFeaturesToTrackWithQuality) void goodFeaturesToTrack(
         InputArray mask, OutputArray cornersQuality, int blockSize = 3,
         int gradientSize = 3, bool useHarrisDetector = false, double k = 0.04);
 
+/** @brief Determines strong corners with adaptive per-tile quality thresholding.
+
+This function extends #goodFeaturesToTrack by estimating a local maximum response in each tile
+of the image and applying the quality threshold relative to this local maximum. It helps preserve
+corners in low-texture regions while still suppressing weak responses inside each tile.
+
+@param image Input 8-bit or floating-point 32-bit, single-channel image.
+@param corners Output vector of detected corners.
+@param maxCorners Maximum number of corners to return. If there are more corners than are found,
+the strongest of them is returned. `maxCorners <= 0` implies that no limit on the maximum is set.
+@param qualityLevel Minimal accepted quality relative to each tile-local maximum response.
+@param minDistance Minimum possible Euclidean distance between the returned corners.
+@param tileGridSize Number of tiles in X and Y direction. Must be positive.
+@param mask Optional region of interest. If not empty, it needs type CV_8UC1 and image size.
+@param blockSize Size of an average block for computing a derivative covariation matrix.
+@param gradientSize Aperture parameter for Sobel derivatives computation.
+@param useHarrisDetector Parameter indicating whether to use #cornerHarris or
+#cornerMinEigenVal.
+@param k Free parameter of the Harris detector.
+
+@code{.cpp}
+cv::Mat gray = cv::imread("frame.png", cv::IMREAD_GRAYSCALE);
+std::vector<cv::Point2f> corners;
+cv::goodFeaturesToTrackAdaptive(gray, corners, 500, 0.02, 5.0,
+                                cv::Size(6, 4), cv::noArray(), 3, 3, false);
+@endcode
+ */
+CV_EXPORTS_W void goodFeaturesToTrackAdaptive(
+        InputArray image, OutputArray corners,
+        int maxCorners, double qualityLevel, double minDistance,
+        Size tileGridSize = Size(4, 4), InputArray mask = noArray(),
+        int blockSize = 3, int gradientSize = 3,
+        bool useHarrisDetector = false, double k = 0.04);
+
 /** @example samples/cpp/tutorial_code/ImgTrans/houghlines.cpp
 An example using the Hough line detector
 ![Sample input image](Hough_Lines_Tutorial_Original_Image.jpg) ![Output image](Hough_Lines_Tutorial_Result.jpg)

--- a/modules/imgproc/src/featureselect.cpp
+++ b/modules/imgproc/src/featureselect.cpp
@@ -547,6 +547,152 @@ void cv::goodFeaturesToTrack( InputArray _image, OutputArray _corners,
     }
 }
 
+void cv::goodFeaturesToTrackAdaptive(InputArray _image, OutputArray _corners,
+                                     int maxCorners, double qualityLevel, double minDistance,
+                                     Size tileGridSize, InputArray _mask,
+                                     int blockSize, int gradientSize,
+                                     bool useHarrisDetector, double harrisK)
+{
+    CV_INSTRUMENT_REGION();
+
+    CV_Assert(qualityLevel > 0 && minDistance >= 0 && maxCorners >= 0);
+    CV_Assert(tileGridSize.width > 0 && tileGridSize.height > 0);
+    CV_Assert(_mask.empty() || (_mask.type() == CV_8UC1 && _mask.sameSize(_image)));
+
+    Mat image = _image.getMat(), eig, tmp;
+    if (image.empty())
+    {
+        _corners.release();
+        return;
+    }
+
+    if (useHarrisDetector)
+        cornerHarris(image, eig, blockSize, gradientSize, harrisK);
+    else
+        cornerMinEigenVal(image, eig, blockSize, gradientSize);
+
+    dilate(eig, tmp, Mat());
+
+    Mat mask = _mask.getMat();
+    Size imgsize = image.size();
+    std::vector<double> tileMax(tileGridSize.area(), 0.0);
+
+    for (int y = 0; y < imgsize.height; ++y)
+    {
+        const float* eig_data = eig.ptr<float>(y);
+        const uchar* mask_data = mask.data ? mask.ptr<uchar>(y) : 0;
+        const int tileY = std::min((y * tileGridSize.height) / imgsize.height, tileGridSize.height - 1);
+
+        for (int x = 0; x < imgsize.width; ++x)
+        {
+            if (mask_data && !mask_data[x])
+                continue;
+
+            const int tileX = std::min((x * tileGridSize.width) / imgsize.width, tileGridSize.width - 1);
+            double& currentMax = tileMax[tileY * tileGridSize.width + tileX];
+            currentMax = std::max(currentMax, static_cast<double>(eig_data[x]));
+        }
+    }
+
+    std::vector<const float*> tmpCorners;
+    for (int y = 1; y < imgsize.height - 1; ++y)
+    {
+        const float* eig_data = eig.ptr<float>(y);
+        const float* tmp_data = tmp.ptr<float>(y);
+        const uchar* mask_data = mask.data ? mask.ptr<uchar>(y) : 0;
+        const int tileY = std::min((y * tileGridSize.height) / imgsize.height, tileGridSize.height - 1);
+
+        for (int x = 1; x < imgsize.width - 1; ++x)
+        {
+            if (mask_data && !mask_data[x])
+                continue;
+
+            const int tileX = std::min((x * tileGridSize.width) / imgsize.width, tileGridSize.width - 1);
+            const double localThreshold = tileMax[tileY * tileGridSize.width + tileX] * qualityLevel;
+            const float val = eig_data[x];
+            if (val > localThreshold && val == tmp_data[x])
+                tmpCorners.push_back(eig_data + x);
+        }
+    }
+
+    if (tmpCorners.empty())
+    {
+        _corners.release();
+        return;
+    }
+
+    std::sort(tmpCorners.begin(), tmpCorners.end(), greaterThanPtr());
+
+    std::vector<Point2f> corners;
+    corners.reserve(tmpCorners.size());
+
+    if (minDistance >= 1)
+    {
+        const int cell_size = cvRound(minDistance);
+        const int grid_width = (image.cols + cell_size - 1) / cell_size;
+        const int grid_height = (image.rows + cell_size - 1) / cell_size;
+        std::vector<std::vector<Point2f> > grid(grid_width * grid_height);
+        const double minDistanceSq = minDistance * minDistance;
+
+        for (size_t i = 0; i < tmpCorners.size(); ++i)
+        {
+            int ofs = (int)((const uchar*)tmpCorners[i] - eig.ptr());
+            int y = (int)(ofs / eig.step);
+            int x = (int)((ofs - y * eig.step) / sizeof(float));
+
+            const int x_cell = x / cell_size;
+            const int y_cell = y / cell_size;
+
+            const int x1 = std::max(0, x_cell - 1);
+            const int y1 = std::max(0, y_cell - 1);
+            const int x2 = std::min(grid_width - 1, x_cell + 1);
+            const int y2 = std::min(grid_height - 1, y_cell + 1);
+
+            bool good = true;
+            for (int yy = y1; yy <= y2 && good; ++yy)
+            {
+                for (int xx = x1; xx <= x2 && good; ++xx)
+                {
+                    const std::vector<Point2f>& m = grid[yy * grid_width + xx];
+                    for (size_t j = 0; j < m.size(); ++j)
+                    {
+                        const float dx = x - m[j].x;
+                        const float dy = y - m[j].y;
+                        if (dx * dx + dy * dy < minDistanceSq)
+                        {
+                            good = false;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (!good)
+                continue;
+
+            grid[y_cell * grid_width + x_cell].push_back(Point2f((float)x, (float)y));
+            corners.push_back(Point2f((float)x, (float)y));
+            if (maxCorners > 0 && (int)corners.size() == maxCorners)
+                break;
+        }
+    }
+    else
+    {
+        for (size_t i = 0; i < tmpCorners.size(); ++i)
+        {
+            int ofs = (int)((const uchar*)tmpCorners[i] - eig.ptr());
+            int y = (int)(ofs / eig.step);
+            int x = (int)((ofs - y * eig.step) / sizeof(float));
+
+            corners.push_back(Point2f((float)x, (float)y));
+            if (maxCorners > 0 && (int)corners.size() == maxCorners)
+                break;
+        }
+    }
+
+    Mat(corners).convertTo(_corners, _corners.fixedType() ? _corners.type() : CV_32F);
+}
+
 CV_IMPL void
 cvGoodFeaturesToTrack( const void* _image, void*, void*,
                        CvPoint2D32f* _corners, int *_corner_count,

--- a/modules/imgproc/test/test_goodfeaturetotrack.cpp
+++ b/modules/imgproc/test/test_goodfeaturetotrack.cpp
@@ -523,5 +523,36 @@ int CV_GoodFeatureToTTest::validate_test_results( int test_case_idx )
 TEST(Imgproc_GoodFeatureToT, accuracy) { CV_GoodFeatureToTTest test; test.safe_run(); }
 
 
+TEST(Imgproc_GoodFeatureToT, adaptive_tile_distribution)
+{
+    Mat image = Mat::zeros(160, 160, CV_8UC1);
+
+    rectangle(image, Rect(12, 12, 44, 44), Scalar(255), FILLED);
+    rectangle(image, Rect(104, 104, 44, 44), Scalar(80), FILLED);
+
+    std::vector<Point2f> cornersGlobal;
+    std::vector<Point2f> cornersAdaptive;
+
+    goodFeaturesToTrack(image, cornersGlobal, 40, 0.10, 2.0);
+    goodFeaturesToTrackAdaptive(image, cornersAdaptive, 40, 0.10, 2.0, Size(2, 2));
+
+    int globalBottomRight = 0;
+    for (size_t i = 0; i < cornersGlobal.size(); ++i)
+    {
+        if (cornersGlobal[i].x > 80.f && cornersGlobal[i].y > 80.f)
+            ++globalBottomRight;
+    }
+
+    int adaptiveBottomRight = 0;
+    for (size_t i = 0; i < cornersAdaptive.size(); ++i)
+    {
+        if (cornersAdaptive[i].x > 80.f && cornersAdaptive[i].y > 80.f)
+            ++adaptiveBottomRight;
+    }
+
+    EXPECT_EQ(0, globalBottomRight);
+    EXPECT_GE(adaptiveBottomRight, 4);
+}
+
 }} // namespace
 /* End of file. */


### PR DESCRIPTION
### Motivation

- Improve corner detection robustness in images with uneven illumination or localized low contrast where the global quality threshold in `goodFeaturesToTrack` can discard useful corners.  
- Provide a drop-in style API that preserves the original non-maximum suppression and min-distance logic while applying a local (per-tile) quality threshold.  
- Enable easy exposure to Python via the header generator by declaring the API with `CV_EXPORTS_W`.

### Description

- Added public API declaration `goodFeaturesToTrackAdaptive(...)` to `modules/imgproc/include/opencv2/imgproc.hpp` with Doxygen docs and an example usage snippet.  
- Implemented `cv::goodFeaturesToTrackAdaptive` in `modules/imgproc/src/featureselect.cpp` that computes the corner response (`cornerMinEigenVal` or `cornerHarris`), builds per-tile maximum responses, applies a tile-local `qualityLevel` threshold, then applies the same non-maximum and min-distance suppression as the existing GFTT implementation.  
- Kept function signature/options similar to `goodFeaturesToTrack` including `maxCorners`, `minDistance`, `blockSize`, `gradientSize`, `useHarrisDetector`, and Harris `k`, and added `Size tileGridSize` to control tile partitioning.  
- Added a unit test `Imgproc_GoodFeatureToT.adaptive_tile_distribution` to `modules/imgproc/test/test_goodfeaturetotrack.cpp` demonstrating the adaptive method retains corners in a low-contrast tile where global thresholding does not.

### Testing

- Added a Google Test case `Imgproc_GoodFeatureToT.adaptive_tile_distribution` that compares the existing `goodFeaturesToTrack` behavior with `goodFeaturesToTrackAdaptive` on a synthetic image and asserts improved corner retention.  
- No full build or test run was executed in this environment because no configured build directory was present, so the new test has not been executed here.  
- The change is limited to existing `imgproc` sources and tests so it should be picked up by the module's normal CMake/test targets without adding new CMake entries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994b122c90c83339d0f317f9eaa0e18)